### PR TITLE
Error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,24 @@ Each site implementing a set of AMP templates should add a new folder to `views`
 ## Notes on Deployment
 
 `NODE_ENV` must be set to `production` in order for the app to run in production mode. Note that this value is also passed to sentry for categorizing uncaught exceptions, so set it to `demo` in the demo infra.
+
+## Configuration
+
+### Legend
+
+| **Symbol**     | **Translation**                            |
+| -------------- | ------------------------------------------ |
+| :white_circle: | Not required.                              |
+| :black_circle: | Required in "live" (prod & demo)           |
+| :red_circle:   | Required in "live", local, and test envs   |
+
+**NOTE** test values are retrieved from `.env.sample`.
+
+### Values
+
+| **Required?**  | **Config Value** | **Description**                                  |
+| -------------- | ---------------- | ------------------------------------------------ |
+| :red_circle:   | `GOTHAMIST_HOST` | Protocol and host to gothamist fastboot backend. |
+| :black_circle: | `NODE_ENV`       | Acceptable values are "prod", "demo", or "dev".  |
+| :white_circle: | `PORT`           | Port number on which to run server.              |
+| :black_circle: | `SENTRY_DSN`     | DSN value for error reporting to sentry.         |

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Each site implementing a set of AMP templates should add a new folder to `views`
 
 ## Notes on Deployment
 
-`NODE_ENV` must be set to `production` in order for the app to run in production mode.
+`NODE_ENV` must be set to `production` in order for the app to run in production mode. Note that this value is also passed to sentry for categorizing uncaught exceptions, so set it to `demo` in the demo infra.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,74 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@sentry/core": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-gK8XfkJIZLsBEQehkr2q2fdHI50B3yo4RXiixSZiNBVIzQ+1z3JcMssDzGwhbY81NHUzHZ7of3oQ4Ab4OGRI/g==",
+      "requires": {
+        "@sentry/hub": "5.6.1",
+        "@sentry/minimal": "5.6.1",
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.6.1.tgz",
+      "integrity": "sha512-m+OhkIV5yTAL3R1+XfCwzUQka0UF/xG4py8sEfPXyYIcoOJ2ZTX+1kQJLy8QQJ4RzOBwZA+DzRKP0cgzPJ3+oQ==",
+      "requires": {
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.6.1.tgz",
+      "integrity": "sha512-ercCKuBWHog6aS6SsJRuKhJwNdJ2oRQVWT2UAx1zqvsbHT9mSa8ZRjdPHYOtqY3DoXKk/pLUFW/fkmAnpdMqRw==",
+      "requires": {
+        "@sentry/hub": "5.6.1",
+        "@sentry/types": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.6.1.tgz",
+      "integrity": "sha512-8gNjFRrTOG3vu2RpWZnUSxNx6Ui2Dthq2VHeVImt7PYtVaSddlYZvt0xl8L/fJC/TvFZEPfX0d8Is9v8yvsgRQ==",
+      "requires": {
+        "@sentry/core": "5.6.1",
+        "@sentry/hub": "5.6.1",
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
+        "cookie": "0.3.1",
+        "https-proxy-agent": "2.2.1",
+        "lru_map": "0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.6.1.tgz",
+      "integrity": "sha512-Kub8TETefHpdhvtnDj3kKfhCj0u/xn3Zi2zIC7PB11NJHvvPXENx97tciz4roJGp7cLRCJsFqCg4tHXniqDSnQ=="
+    },
+    "@sentry/utils": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.6.1.tgz",
+      "integrity": "sha512-rfgha+UsHW816GqlSRPlniKqAZylOmQWML2JsujoUP03nPu80zdN43DK9Poy/d9OxBxv0gd5K2n+bFdM2kqLQQ==",
+      "requires": {
+        "@sentry/types": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -62,6 +130,14 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
     },
     "ajv": {
       "version": "6.10.2",
@@ -582,6 +658,19 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-html": {
@@ -1133,6 +1222,30 @@
         "sshpk": "^1.7.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1462,6 +1575,11 @@
       "requires": {
         "chalk": "^2.0.1"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -2482,8 +2600,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -911,6 +911,11 @@
         "vary": "~1.1.2"
       }
     },
+    "express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng=="
+    },
     "express-handlebars": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/nypublicradio/champ#readme",
   "dependencies": {
+    "@sentry/node": "^5.6.1",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
     "express-handlebars": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@sentry/node": "^5.6.1",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
+    "express-async-errors": "^3.1.1",
     "express-handlebars": "^3.1.0",
     "jsdom": "^15.1.1",
     "request-promise-native": "^1.0.7"

--- a/src/app.js
+++ b/src/app.js
@@ -1,10 +1,16 @@
 const express = require('express');
 const hbs = require('express-handlebars');
+const Sentry = require('@sentry/node');
 
 const gothamist = require('../routes/gothamist');
 
 
 const app = express();
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.NODE_ENV || 'dev',
+});
 
 // express error handlers require an arity of 4
 // eslint-disable-next-line no-unused-vars
@@ -16,8 +22,10 @@ const errorHandler = (err, req, res, next) => {
 app.engine('hbs', hbs());
 app.set('view engine', 'hbs');
 
+app.use(Sentry.Handlers.requestHandler());
 app.use('/gothamist', gothamist);
 
+app.use(Sentry.Handlers.errorHandler());
 app.use(errorHandler);
 
 module.exports = app;

--- a/src/app.js
+++ b/src/app.js
@@ -9,7 +9,7 @@ const app = express();
 // express error handlers require an arity of 4
 // eslint-disable-next-line no-unused-vars
 const errorHandler = (err, req, res, next) => {
-  res.status(err.statusCode);
+  res.status(err.statusCode || 500);
   res.render('error', {layout: false});
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,5 @@
+require('express-async-errors');
+
 const express = require('express');
 const hbs = require('express-handlebars');
 const Sentry = require('@sentry/node');


### PR DESCRIPTION
@ncastro-nypr here are the error handing updates we talked about.

most of this is boilerplate, but it makes for a significant difference. 

If you add a `throw 'error'` line in `routes/gothamist` and run the app on `master`, when you make a request to `localhost:8000/gothamist/foo/bar` to trigger the unhandled exception, you'll see that the request never returns (even tho you'll see an error printed to the console). this is due to the fact that none of the "success" calls are made (`response.render`, `response.end`, etc.), and the `next` middleware parameter is also uncalled, so express keeps waiting for that request to end, which it never will.

the `express-async-errors` library patches express so that any route handler that returns a promise (i.e. is an `async` function) [calls `next` in its exception handler](https://github.com/davidbanham/express-async-errors/blob/master/index.js#L18).